### PR TITLE
Fix user timestamps handling

### DIFF
--- a/src/main/java/com/blog/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/blog/domain/user/repository/UserRepository.java
@@ -5,6 +5,7 @@ import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.jdbc.core.RowMapper;
 import org.springframework.stereotype.Repository;
 
+import java.sql.Timestamp;
 import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
@@ -18,13 +19,15 @@ public class UserRepository {
   }
 
   public void save(User user) {
-    String sql = "INSERT INTO user (id, nickname, password, email, profile_image_url) VALUES (?, ?, ?, ?, ?)";
+    String sql = "INSERT INTO user (id, nickname, password, email, profile_image_url, created_at, updated_at) VALUES (?, ?, ?, ?, ?, ?, ?)";
     jdbcTemplate.update(sql,
         user.getId().toString(),
         user.getNickname(),
         user.getPassword(),
         user.getEmail(),
-        user.getProfileImageUrl()
+        user.getProfileImageUrl(),
+        Timestamp.valueOf(user.getCreatedAt()),
+        Timestamp.valueOf(user.getUpdatedAt())
     );
   }
 

--- a/src/main/java/com/blog/global/auth/service/AuthService.java
+++ b/src/main/java/com/blog/global/auth/service/AuthService.java
@@ -5,6 +5,7 @@ import com.blog.domain.user.dto.SignupRequest;
 import com.blog.domain.user.repository.UserRepository;
 import com.blog.global.auth.jwtUtil.JwtUtil;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.LocalDateTime;
 import java.util.UUID;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.*;
@@ -62,8 +63,8 @@ public class AuthService {
         hashedPassword,
         request.getEmail(),
         request.getProfileImageUrl(),
-        null,
-        null
+        LocalDateTime.now(),
+        LocalDateTime.now()
     );
 
     userRepository.save(newUser);


### PR DESCRIPTION
## Summary
- insert timestamp columns when saving users
- set created_at and updated_at during signup

## Testing
- `./gradlew test --no-daemon` *(fails: Unable to tunnel through proxy)*

------
https://chatgpt.com/codex/tasks/task_e_683fef50b1c0832ea7b06cc4bf427dde